### PR TITLE
Fix: Update deprecated constants to ensure compatibility with Home Assistant 2025.1

### DIFF
--- a/custom_components/hp_ilo/__init__.py
+++ b/custom_components/hp_ilo/__init__.py
@@ -12,18 +12,20 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from .sensor import DOMAIN
+
 PLATFORMS = [Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up entites of all platforms from a config entry."""
-    #hass.data.setdefault(DOMAIN, {})
+    """Set up entities of all platforms from a config entry."""
+    hass.data.setdefault(DOMAIN, {})  # Ensure DOMAIN key exists
+    hass.data[DOMAIN][entry.entry_id] = entry  # Store entry data
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DOMAIN].pop(entry.entry_id, None)  # Safely remove entry
     return unload_ok

--- a/custom_components/hp_ilo/sensor.py
+++ b/custom_components/hp_ilo/sensor.py
@@ -35,7 +35,9 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
     CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
-    PERCENTAGE,TEMP_CELSIUS,TIME_SECONDS
+    PERCENTAGE,
+    UnitOfTemperature,  # Updated import for temperature unit
+    UnitOfTime,         # Updated import for time unit
 )
 from homeassistant.const import (
     CONF_HOST, 
@@ -302,23 +304,23 @@ async def async_setup_entry(
 
             if sensor_type == "server_health":
                 for health_value_keys in sensor_data:
-                    if(health_value_keys == 'temperature'):
+                    if health_value_keys == 'temperature':
                         for temperature_sensor in sensor_data[health_value_keys].values():
                             if temperature_sensor['status'] != 'Not Installed':
-                                _LOGGER.info("Adding sensor for Temperature Sensor %s",temperature_sensor['label'])
+                                _LOGGER.info("Adding sensor for Temperature Sensor %s", temperature_sensor['label'])
                                 new_sensor = HpIloDeviceSensor(
                                     hass=hass,
                                     hp_ilo_data=hp_ilo_data,
                                     sensor_name=temperature_sensor['label'],
                                     sensor_type=sensor_type,
-                                    sensor_value_template=template.Template('{{ ilo_data.temperature["'+temperature_sensor['label']+'"].currentreading[0] }}'),
-                                    unit_of_measurement=TEMP_CELSIUS,
+                                    sensor_value_template=template.Template('{{ ilo_data.temperature["' + temperature_sensor['label'] + '"].currentreading[0] }}'),
+                                    unit_of_measurement=UnitOfTemperature.CELSIUS,  # Updated to UnitOfTemperature.CELSIUS
                                     device_class=SensorDeviceClass.TEMPERATURE,
                                     state_class=SensorStateClass.MEASUREMENT,
                                     entry=entry,
                                     device_info=device_info
                                 )
-                                sensors.append(new_sensor )
+                                sensors.append(new_sensor)
                     if(health_value_keys == 'fans'):
                         for fan_sensor in sensor_data[health_value_keys].values():
                             _LOGGER.info("Adding sensor for Fan %s ",fan_sensor['label'])
@@ -343,18 +345,18 @@ async def async_setup_entry(
             elif sensor_type == "server_power_on_time":
                 _LOGGER.info("Adding sensor for %s", sensor_type_name)
                 new_sensor = HpIloDeviceSensor(
-                            hass=hass,
-                            hp_ilo_data=hp_ilo_data,
-                            sensor_name=sensor_type_name,
-                            sensor_type=sensor_type,
-                            sensor_value_template=template.Template('{{ ilo_data }}'),
-                            unit_of_measurement=TIME_SECONDS,
-                            device_class=None,# TODO: it's not clear what entity is best for this
-                            state_class=None,# TODO:  it's not clear what entity is best for this
-                            entry=entry,
-                            device_info=device_info
-                        )
-                sensors.append(new_sensor )
+                    hass=hass,
+                    hp_ilo_data=hp_ilo_data,
+                    sensor_name=sensor_type_name,
+                    sensor_type=sensor_type,
+                    sensor_value_template=template.Template('{{ ilo_data }}'),
+                    unit_of_measurement=UnitOfTime.SECONDS,  # Updated to UnitOfTime.SECONDS
+                    device_class=None,  # TODO: it's not clear what entity is best for this
+                    state_class=None,  # TODO: it's not clear what entity is best for this
+                    entry=entry,
+                    device_info=device_info
+                )
+                sensors.append(new_sensor)
             elif sensor_type == "server_power_status":
                 _LOGGER.info("Adding sensor for %s", sensor_type_name)
                 new_sensor = HpIloDeviceSensor(

--- a/custom_components/hp_ilo/strings.json
+++ b/custom_components/hp_ilo/strings.json
@@ -23,9 +23,8 @@
         }
       },
       "confirm": {
-        "title": "Confirm adding Apple TV",
-        "description": "You are about to add `{name}` ({description}) at `{host}`  to Home Assistant.\n\n **To complete the process, enter your ILO username + password.**"
-       
+        "title": "Confirm adding HP iLO",
+        "description": "You are about to add `{name}` ({description}) at `{host}` to Home Assistant.\n\n **To complete the process, enter your iLO username and password.**"
       }
     },
     "abort": {


### PR DESCRIPTION
I'm not sure if this repository is still actively maintained, and I'm not an expert in Python, but I attempted to fix the issue using ChatGPT. By providing the sensor.py file and the error message, ChatGPT helped me update the deprecated constants.

The following changes were made:

Replaced deprecated constants TEMP_CELSIUS and TIME_SECONDS with the updated UnitOfTemperature.CELSIUS and UnitOfTime.SECONDS respectively.
As a result, I can now restart Home Assistant without errors. The sensors that used to reference TEMP_CELSIUS or TIME_SECONDS are functioning correctly, and there are no log errors after reboot.

Additionally, I updated the strings.json file to adjust the wording to be relevant to HP iLO. However, I'm unsure if the config flow is fully functional.

This should resolve issue #2.  

Thanks for your consideration!