### PR TITLE
Implement more diagnostic & sensor entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,62 @@ A drop-in replacement for the [official HP iLO integration](https://www.home-ass
 - **Binary sensor for power state** — Proper ON/OFF binary sensor instead of enum
 - **Safe defaults** — All power control entities disabled by default to prevent accidental shutdowns
 
-# Installation
+<h3>🌡️ Hardware Health Sensors</h3>
+<ul>
+<li><strong>Temperature sensors</strong>: All thermal zones exposed with number prefix stripped from display names (e.g. <code>01-Inlet Ambient</code> → <code>Inlet Ambient</code>)</li>
+<li><strong>Fan sensors</strong>: Per-fan speed as percentage</li>
+<li><strong>Memory DIMM sensors</strong>: Per installed DIMM — size @ speed as state (e.g. <code>8192 MB @ 1600 MHz</code>), DDR type inferred from speed, location as attribute</li>
+<li><strong>Processor sensors</strong>: Status per CPU plus dedicated entities for name, speed, execution technology, and memory technology</li>
+<li><strong>NIC sensor</strong>: MAC, IP, gateway, DNS, speed/duplex (merged from <code>nic_information</code> and <code>network_settings</code>)</li>
+<li><strong>Storage controller sensors</strong>: Per controller with drive and logical volume details as attributes</li>
+<li><strong>BIOS/Hardware aggregate sensor</strong>: Rolled-up hardware health</li>
+</ul>
+<h3>🔧 Firmware Information</h3>
+<p>All firmware components exposed as individual diagnostic sensors, discovered dynamically (no hardcoded key names, works across server generations):</p>
+<ul>
+<li>System ROM &amp; Redundant System ROM (version + date)</li>
+<li>System ROM Bootblock</li>
+<li>Intelligent Provisioning</li>
+<li>Intelligent Platform Abstraction Data</li>
+<li>Server Platform Services (SPS) Firmware</li>
+<li>System Programmable Logic Device</li>
+</ul>
+<h3>📋 Event Logs</h3>
+<ul>
+<li><strong>iLO Event Log</strong> &amp; <strong>Server Event Log</strong> sensors: worst severity across all entries as state, full log (up to 50 entries, newest first) in attributes</li>
+<li>Per-field sensors for last critical entry: description, timestamp, class</li>
+<li><strong>Clear iLO Event Log</strong> &amp; <strong>Clear Server Event Log</strong> buttons (requires <code>CONFIG_ILO_PRIV</code> on the iLO user — see below)</li>
+</ul>
+<h3>🔍 iLO Self-Tests (Health-at-a-Glance)</h3>
+<p>One sensor per iLO subsystem showing the iLO's own rolled-up self-test result (OK / Degraded / Failed) for: BIOS, fans, temperature, power supplies, processor, memory, network, storage.</p>
+<h3>⚡ Power Monitoring</h3>
+<ul>
+<li>Present, Average, Minimum, Maximum power readings (Watts) — where supported by iLO firmware</li>
+<li>Power Saver mode (AUTO / OS Control / Static High / Static Low)</li>
+<li>Power Cap mode with efficiency mode and alert thresholds</li>
+</ul>
+<h3>🏷️ System Identity</h3>
+<ul>
+<li>iLO Firmware Version (with management processor type, license, date)</li>
+<li>Asset Tag</li>
+<li>Server Power-On Time</li>
+</ul>
+<h3>🔴 Binary Sensors</h3>
+<ul>
+<li>Per-subsystem health (Memory, Processor, Network, Storage, Temperature, Fan) — fires when any status is Degraded/Failed/Critical/Warning</li>
+<li>UID Locator Light status</li>
+<li>Critical Temp Remain Off configuration</li>
+</ul>
 
+# Installation
 Add this repo as a custom repo to HACS and the integration should show up. 
+
+<hr>
+<h2>Required User Actions</h2>
+<h3>iLO User Privileges for Log Clearing</h3>
+<p>The <strong>Clear iLO Event Log</strong> and <strong>Clear Server Event Log</strong> buttons require the <strong>Configure iLO Settings (<code>CONFIG_ILO_PRIV</code>)</strong> privilege.</p>
+<p>To grant it: iLO web UI → <strong>Administration → User Administration</strong> → select the HA user → enable <strong>"Configure iLO Settings"</strong> → Save.</p>
+<p>Without this privilege, pressing the buttons will produce a <code>CONFIG_ILO_PRIV required</code> error in the HA log — all other entities work with standard read-only access.</p>
 
 # Features
 
@@ -104,16 +157,28 @@ pytest tests/test_config_flow.py -v
 # Run with coverage
 pytest tests/ --cov=custom_components.hp_ilo
 ```
+<hr>
+<h2>Bug Fixes Included</h2>
 
----
+Bug | Fix
+-- | --
+IloWarning ("No Asset Tag Information") polluting HA logs | Suppressed via warnings.catch_warnings() around every API call
+Storage sensor crash when health['storage'] is None | Added isinstance(..., dict) guard
+NIC sensor showing unknown | Falls back to MAC address when IP is N/A
+NIC MAC mismatch skipping network_settings merge | Removed cross-check — management port and shared NIC use adjacent MACs by design
+Storage Health binary sensor showing unknown | Returns False instead of None when data is absent
+Memory sensor crash on Gen8 | Rewrote to parse memory_components tuple structure instead of memory_details_summary
+Memory Other status triggering health fault | Other excluded from _FAULT_STATUSES
+Firmware sensors not found on Gen8 | Dynamic key discovery replaces hardcoded Gen8+ key names
+Temperature labels with number prefix | ^\d+- stripped from display name, original kept as unique ID
+Entity names missing device prefix | _attr_has_entity_name = True added to base classes
+Health/config entities not in diagnostics panel | EntityCategory.DIAGNOSTIC applied to all non-primary entities
 
-# TODO
-
-- **Configuration improvements**
-  - Update of IPs and Hostname from discovery in case any of them change
-  - Import of existing sensors from configuration.yaml
-  - Option to enable/disable what sensors and other entities/platforms are added
-
-- **Strings and Translations** — Config flow should support i18n
-
-- **Firmware Upgrades** — Buttons for [firmware upgrades](https://seveas.github.io/python-hpilo/firmware.html) using the python-hpilo library
+<hr>
+<h2>Tested On</h2>
+<ul>
+<li>HP ProLiant MicroServer Gen8</li>
+<li>iLO 4 firmware <code>2.82 Feb 06 2023</code></li>
+<li>Intel Xeon E3-1220 V2, mixed DDR3 DIMMs</li>
+<li>Home Assistant with <code>python-hpilo</code></li>
+</ul>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Add this repo as a custom repo to HACS and the integration should show up.
 <p>To grant it: iLO web UI → <strong>Administration → User Administration</strong> → select the HA user → enable <strong>"Configure iLO Settings"</strong> → Save.</p>
 <p>Without this privilege, pressing the buttons will produce a <code>CONFIG_ILO_PRIV required</code> error in the HA log — all other entities work with standard read-only access.</p>
 <hr>
+
 # Features
 
 ## Discovery
@@ -180,4 +181,5 @@ Health/config entities not in diagnostics panel | EntityCategory.DIAGNOSTIC appl
 <li>Intel Xeon E3-1220 V2, mixed DDR3 DIMMs</li>
 <li>Home Assistant with <code>python-hpilo</code></li>
 </ul>
+
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,12 @@ A drop-in replacement for the [official HP iLO integration](https://www.home-ass
 # Installation
 Add this repo as a custom repo to HACS and the integration should show up. 
 
-<hr>
 <h2>Required User Actions</h2>
 <h3>iLO User Privileges for Log Clearing</h3>
 <p>The <strong>Clear iLO Event Log</strong> and <strong>Clear Server Event Log</strong> buttons require the <strong>Configure iLO Settings (<code>CONFIG_ILO_PRIV</code>)</strong> privilege.</p>
 <p>To grant it: iLO web UI → <strong>Administration → User Administration</strong> → select the HA user → enable <strong>"Configure iLO Settings"</strong> → Save.</p>
 <p>Without this privilege, pressing the buttons will produce a <code>CONFIG_ILO_PRIV required</code> error in the HA log — all other entities work with standard read-only access.</p>
-
+<hr>
 # Features
 
 ## Discovery
@@ -174,7 +173,6 @@ Temperature labels with number prefix | ^\d+- stripped from display name, origin
 Entity names missing device prefix | _attr_has_entity_name = True added to base classes
 Health/config entities not in diagnostics panel | EntityCategory.DIAGNOSTIC applied to all non-primary entities
 
-<hr>
 <h2>Tested On</h2>
 <ul>
 <li>HP ProLiant MicroServer Gen8</li>
@@ -182,3 +180,4 @@ Health/config entities not in diagnostics panel | EntityCategory.DIAGNOSTIC appl
 <li>Intel Xeon E3-1220 V2, mixed DDR3 DIMMs</li>
 <li>Home Assistant with <code>python-hpilo</code></li>
 </ul>
+

--- a/custom_components/hp_ilo/binary_sensor.py
+++ b/custom_components/hp_ilo/binary_sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -9,7 +10,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import CONNECTION_UPNP
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -26,11 +27,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up HP iLO binary sensor entities."""
-    
-    # Get the coordinator from hass.data
+
     coordinator: HpIloDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # config flow sets this to either UUID, serial number or None
     if (unique_id := entry.unique_id) is None:
         unique_id = entry.entry_id
 
@@ -44,53 +43,193 @@ async def async_setup_entry(
         manufacturer="Hewlett Packard Enterprise",
         configuration_url=configuration_url,
         connections=connections,
-        identifiers=identifiers
+        identifiers=identifiers,
     )
 
     binary_sensors = []
+    data = coordinator.data
 
-    # Add power status binary sensor if power status is available
-    if coordinator.data and coordinator.data.power_status is not None:
+    # ------------------------------------------------------------------ power
+    if data and data.power_status is not None:
         _LOGGER.info("Adding binary sensor for Server Power Status")
-        binary_sensors.append(
-            HpIloPowerStatusBinarySensor(
-                coordinator=coordinator,
-                entry=entry,
-                device_info=device_info
-            )
-        )
+        binary_sensors.append(HpIloPowerStatusBinarySensor(coordinator, entry, device_info))
+
+    # --------------------------------------------------------------- subsystem health
+    if data and data.health:
+        health = data.health
+        HEALTH_SUBSYSTEMS = [
+            ('bios_hardware',   "BIOS Hardware Health"),
+            ('memory',          "Memory Health"),
+            ('processors',      "Processor Health"),
+            ('nic_information', "Network Health"),
+            ('storage',         "Storage Health"),
+            ('temperature',     "Temperature Health"),
+            ('fans',            "Fan Health"),
+        ]
+        for subsystem_key, sensor_name in HEALTH_SUBSYSTEMS:
+            if subsystem_key in health:
+                _LOGGER.info("Adding binary sensor for %s", sensor_name)
+                binary_sensors.append(
+                    HpIloSubsystemHealthBinarySensor(
+                        coordinator, entry, device_info, subsystem_key, sensor_name
+                    )
+                )
+
+    # ------------------------------------------------------------------- UID light
+    if data and data.uid_status is not None:
+        _LOGGER.info("Adding binary sensor for UID Light")
+        binary_sensors.append(HpIloUidLightBinarySensor(coordinator, entry, device_info))
+
+    # -------------------------------------------------------- critical temp remain off
+    if data and data.critical_temp_remain_off is not None:
+        _LOGGER.info("Adding binary sensor for Critical Temp Remain Off")
+        binary_sensors.append(HpIloCriticalTempRemainOffBinarySensor(coordinator, entry, device_info))
 
     async_add_entities(binary_sensors, False)
 
 
-class HpIloPowerStatusBinarySensor(CoordinatorEntity[HpIloDataUpdateCoordinator], BinarySensorEntity):
+# ---------------------------------------------------------------------------
+# Base helper
+# ---------------------------------------------------------------------------
+
+class _HpIloBinarySensor(CoordinatorEntity[HpIloDataUpdateCoordinator], BinarySensorEntity):
+    """Shared base for all HP iLO binary sensor entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, entry, device_info, unique_suffix, name):
+        super().__init__(coordinator)
+        self._attr_device_info = device_info
+        self._attr_name = name
+        self._attr_unique_id = f"{entry.data['unique_id']}_{unique_suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Power binary sensor
+# ---------------------------------------------------------------------------
+
+class HpIloPowerStatusBinarySensor(_HpIloBinarySensor):
     """Binary sensor for HP iLO server power status."""
 
     _attr_device_class = BinarySensorDeviceClass.POWER
 
-    def __init__(
-        self,
-        coordinator: HpIloDataUpdateCoordinator,
-        entry: ConfigEntry,
-        device_info: DeviceInfo,
-    ) -> None:
-        """Initialize the binary sensor."""
-        super().__init__(coordinator)
-        self._attr_device_info = device_info
-        self._attr_name = "Server Power"
-        self._attr_unique_id = f"{entry.data['unique_id']}_server_power"
-        # Set initial state
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "server_power", "Server Power")
         self._update_state()
 
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
         self._update_state()
         super()._handle_coordinator_update()
 
     def _update_state(self) -> None:
-        """Update the binary sensor state from coordinator data."""
         if not self.coordinator.data or self.coordinator.data.power_status is None:
             self._attr_is_on = None
         else:
-            # get_host_power_status returns "ON" or "OFF"
             self._attr_is_on = self.coordinator.data.power_status == "ON"
+
+
+# ---------------------------------------------------------------------------
+# Subsystem health binary sensor
+# ---------------------------------------------------------------------------
+
+class HpIloSubsystemHealthBinarySensor(_HpIloBinarySensor):
+    """Binary sensor for HP iLO subsystem health.
+
+    Device class PROBLEM: is_on=True means a fault is detected.
+    is_on=False means all statuses are OK (or subsystem is not present).
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    _FAULT_STATUSES = {"Degraded", "Failed", "Critical", "Warning", "Not Redundant"}
+
+    def __init__(self, coordinator, entry, device_info, subsystem_key, sensor_name):
+        super().__init__(coordinator, entry, device_info, f"{subsystem_key}_health", sensor_name)
+        self._subsystem_key = subsystem_key
+
+    def _collect_statuses(self, data: object) -> list[str]:
+        statuses: list[str] = []
+        if isinstance(data, dict):
+            if 'status' in data and isinstance(data['status'], str):
+                statuses.append(data['status'])
+            for val in data.values():
+                statuses.extend(self._collect_statuses(val))
+        elif isinstance(data, list):
+            for item in data:
+                statuses.extend(self._collect_statuses(item))
+        return statuses
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        subsystem_data = self.coordinator.data.health.get(self._subsystem_key)
+        # None = subsystem not present → no problem
+        if subsystem_data is None:
+            return False
+        statuses = self._collect_statuses(subsystem_data)
+        if not statuses:
+            return False
+        return any(s in self._FAULT_STATUSES for s in statuses)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return {}
+        subsystem_data = self.coordinator.data.health.get(self._subsystem_key)
+        if not subsystem_data:
+            return {}
+        statuses = self._collect_statuses(subsystem_data)
+        return {"statuses": list(set(statuses))} if statuses else {}
+
+
+# ---------------------------------------------------------------------------
+# UID indicator light binary sensor
+# ---------------------------------------------------------------------------
+
+class HpIloUidLightBinarySensor(_HpIloBinarySensor):
+    """Binary sensor for the HP iLO UID (Unit Identification) indicator light.
+
+    is_on=True  → UID light is ON  (server is being identified/located)
+    is_on=False → UID light is OFF
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:led-on"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "uid_light", "UID Light")
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self.coordinator.data or self.coordinator.data.uid_status is None:
+            return None
+        return self.coordinator.data.uid_status.upper() == "ON"
+
+
+# ---------------------------------------------------------------------------
+# Critical temperature remain-off binary sensor
+# ---------------------------------------------------------------------------
+
+class HpIloCriticalTempRemainOffBinarySensor(_HpIloBinarySensor):
+    """Binary sensor for the 'remain off after critical temperature' setting.
+
+    is_on=True  → server will stay powered off after a thermal shutdown
+    is_on=False → server will restart automatically after a thermal shutdown
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:thermometer-alert"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(
+            coordinator, entry, device_info,
+            "critical_temp_remain_off", "Critical Temp Remain Off"
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        if not self.coordinator.data or self.coordinator.data.critical_temp_remain_off is None:
+            return None
+        return self.coordinator.data.critical_temp_remain_off

--- a/custom_components/hp_ilo/button.py
+++ b/custom_components/hp_ilo/button.py
@@ -61,6 +61,18 @@ async def async_setup_entry(
             entry=entry,
             device_info=device_info
         ),
+        HpIloClearEventLogButton(
+            coordinator=coordinator,
+            entry=entry,
+            device_info=device_info,
+            log_type="ilo",
+        ),
+        HpIloClearEventLogButton(
+            coordinator=coordinator,
+            entry=entry,
+            device_info=device_info,
+            log_type="server",
+        ),
     ]
 
     async_add_entities(buttons, False)
@@ -77,6 +89,7 @@ class HpIloPowerButton(ButtonEntity):
     (e.g., if Home Assistant is running on the same machine).
     """
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:power"
     _attr_entity_registry_enabled_default = False  # Disabled by default - destructive action
 
@@ -127,6 +140,7 @@ class HpIloPowerButtonHold(ButtonEntity):
     (e.g., if Home Assistant is running on the same machine).
     """
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:power-cycle"
     _attr_entity_registry_enabled_default = False  # Disabled by default - destructive action
 
@@ -173,6 +187,7 @@ class HpIloResetButton(ButtonEntity):
     (e.g., if Home Assistant is running on the same machine).
     """
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:restart"
     _attr_entity_registry_enabled_default = False  # Disabled by default - disruptive action
 
@@ -206,4 +221,57 @@ class HpIloResetButton(ButtonEntity):
             hpilo.IloCommunicationError,
         ) as error:
             _LOGGER.error("Failed to reset server: %s", error)
+            raise
+
+
+class HpIloClearEventLogButton(ButtonEntity):
+    """Button to clear an iLO or server (IML) event log.
+
+    Clearing the iLO event log calls ilo.clear_ilo_event_log() (RIBCL CLEAR_EVENTLOG).
+    Clearing the server event log calls ilo.clear_server_event_log() (RIBCL CLEAR_IML).
+
+    Both buttons are enabled by default — clearing a log is reversible (data is gone,
+    but it doesn't affect server operation).
+    """
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:notification-clear-all"
+
+    def __init__(
+        self,
+        coordinator: HpIloDataUpdateCoordinator,
+        entry: ConfigEntry,
+        device_info: DeviceInfo,
+        log_type: str,  # "ilo" or "server"
+    ) -> None:
+        self.coordinator = coordinator
+        self._attr_device_info = device_info
+        self._log_type = log_type
+        if log_type == "ilo":
+            self._attr_name = "Clear iLO Event Log"
+            self._attr_unique_id = f"{entry.data['unique_id']}_clear_ilo_event_log"
+        else:
+            self._attr_name = "Clear Server Event Log"
+            self._attr_unique_id = f"{entry.data['unique_id']}_clear_server_event_log"
+
+    async def async_press(self) -> None:
+        """Clear the selected event log and refresh coordinator data."""
+        if not self.coordinator.data or not self.coordinator.data.ilo:
+            _LOGGER.error("No iLO connection available")
+            return
+
+        ilo = self.coordinator.data.ilo
+        method = (
+            ilo.clear_ilo_event_log
+            if self._log_type == "ilo"
+            else ilo.clear_server_event_log
+        )
+        log_label = "iLO event log" if self._log_type == "ilo" else "server event log"
+
+        try:
+            await self.hass.async_add_executor_job(method)
+            _LOGGER.info("Successfully cleared %s", log_label)
+            await self.coordinator.async_request_refresh()
+        except (hpilo.IloError, hpilo.IloCommunicationError) as error:
+            _LOGGER.error("Failed to clear %s: %s", log_label, error)
             raise

--- a/custom_components/hp_ilo/const.py
+++ b/custom_components/hp_ilo/const.py
@@ -1,0 +1,42 @@
+"""Constants for the HP iLO integration."""
+
+DOMAIN = "hp_ilo"
+
+# Config entry keys
+CONF_HOST = "host"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+CONF_PORT = "port"
+CONF_SCAN_INTERVAL = "scan_interval"
+
+# Default values
+DEFAULT_PORT = 443
+DEFAULT_SCAN_INTERVAL = 60  # seconds
+
+# Sensor types supported by the coordinator-based sensor platform.
+# These map directly to fields on HpIloData (coordinator.data).
+SENSOR_TYPES = {
+    # Simple scalar fields
+    "server_name":           {"key": "server_name",         "unit": None},
+    "server_fqdn":           {"key": "server_fqdn",         "unit": None},
+    "server_power_status":   {"key": "server_power_status", "unit": None},
+    "server_power_on_time":  {"key": "server_power_on_time","unit": "min"},
+    "server_uid_status":     {"key": "server_uid_status",   "unit": None},
+    # Dict / template-based fields (value_template required for useful output)
+    "server_health":         {"key": "server_health",       "unit": None},
+    "server_host_data":      {"key": "server_host_data",    "unit": None},
+    "network_settings":      {"key": "network_settings",    "unit": None},
+}
+
+# Legacy sensor_type → coordinator data key mapping
+# (mirrors what the old YAML sensor platform called via hpilo)
+LEGACY_SENSOR_TYPE_MAP = {
+    "server_name":         "server_name",
+    "server_fqdn":         "server_fqdn",
+    "server_host_data":    "server_host_data",
+    "server_power_status": "server_power_status",
+    "server_power_on_time":"server_power_on_time",
+    "server_uid_status":   "server_uid_status",
+    "server_health":       "server_health",
+    "network_settings":    "network_settings",
+}

--- a/custom_components/hp_ilo/coordinator.py
+++ b/custom_components/hp_ilo/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinator for HP iLO integration."""
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -24,22 +25,52 @@ UPDATE_INTERVAL = timedelta(seconds=60)
 @dataclass
 class HpIloData:
     """Class to hold all HP iLO data fetched in a single update cycle."""
-    
-    # Server health data (temperatures, fans, firmware info, etc.)
+
+    # Server health data (temperatures, fans, processors, memory, NIC, storage)
     health: dict[str, Any] | None = None
-    
+
     # Power status ("ON" or "OFF")
     power_status: str | None = None
-    
+
     # Power on time in minutes
     power_on_time: int | None = None
-    
+
     # Server name
     server_name: str | None = None
-    
-    # Host data (SMBIOS entries)
+
+    # Host data (SMBIOS entries: model, BIOS version, serial, memory DIMMs, etc.)
     host_data: list[dict] | None = None
-    
+
+    # Network settings (iLO management NIC: IP, MAC, DNS, gateway, etc.)
+    network_settings: dict | None = None
+
+    # iLO firmware version, type and license
+    fw_version: dict | None = None
+
+    # Present, min, max and average power readings in Watts
+    power_readings: dict | None = None
+
+    # UID indicator light status ("ON" / "OFF")
+    uid_status: str | None = None
+
+    # Server asset tag string (or None if not set)
+    asset_tag: str | None = None
+
+    # Power regulator / saver mode dict  e.g. {'host_power_saver': 'AUTO'}
+    power_saver: dict | None = None
+
+    # Power cap, alert thresholds and efficiency mode
+    pwreg: dict | None = None
+
+    # Whether server stays powered off after a critical temperature shutdown
+    critical_temp_remain_off: bool | None = None
+
+    # iLO event log entries (list of dicts, most-recent first)
+    ilo_event_log: list[dict] | None = None
+
+    # Integrated Management Log / server event log entries (most-recent first)
+    server_event_log: list[dict] | None = None
+
     # Raw iLO connection for commands (buttons, switch actions)
     ilo: hpilo.Ilo | None = None
 
@@ -60,7 +91,7 @@ class HpIloDataUpdateCoordinator(DataUpdateCoordinator[HpIloData]):
         self.port = int(entry.data["port"])
         self.username = entry.data["username"]
         self.password = entry.data["password"]
-        
+
         super().__init__(
             hass,
             _LOGGER,
@@ -70,12 +101,11 @@ class HpIloDataUpdateCoordinator(DataUpdateCoordinator[HpIloData]):
 
     async def _async_update_data(self) -> HpIloData:
         """Fetch data from HP iLO.
-        
-        This is called by the coordinator at the configured interval.
-        All entities will receive the same data from this single fetch.
+
+        Called by the coordinator at the configured interval.
+        All entities receive the same data from this single fetch.
         """
         try:
-            # Run the blocking iLO calls in the executor
             return await self.hass.async_add_executor_job(self._fetch_data)
         except hpilo.IloLoginFailed as err:
             raise UpdateFailed(f"Authentication failed: {err}") from err
@@ -87,50 +117,49 @@ class HpIloDataUpdateCoordinator(DataUpdateCoordinator[HpIloData]):
     def _fetch_data(self) -> HpIloData:
         """Fetch all data from HP iLO (runs in executor thread)."""
         _LOGGER.debug("Fetching data from HP iLO at %s:%s", self.host, self.port)
-        
-        # Create a new iLO connection
+
         ilo = hpilo.Ilo(
             hostname=self.host,
             login=self.username,
             password=self.password,
             port=self.port,
         )
-        
+
         data = HpIloData(ilo=ilo)
-        
-        # Fetch all the data we need in one batch
-        # Each of these is a separate API call, but they all happen
-        # in this single update cycle and the results are cached
-        
-        # Get embedded health (temperatures, fans, firmware)
-        try:
-            data.health = ilo.get_embedded_health()
-        except (hpilo.IloError, hpilo.IloFeatureNotSupported) as err:
-            _LOGGER.debug("Could not get embedded health: %s", err)
-        
-        # Get power status
-        try:
-            data.power_status = ilo.get_host_power_status()
-        except (hpilo.IloError, hpilo.IloFeatureNotSupported) as err:
-            _LOGGER.debug("Could not get power status: %s", err)
-        
-        # Get power on time
-        try:
-            data.power_on_time = ilo.get_server_power_on_time()
-        except (hpilo.IloError, hpilo.IloFeatureNotSupported) as err:
-            _LOGGER.debug("Could not get power on time: %s", err)
-        
-        # Get server name
-        try:
-            data.server_name = ilo.get_server_name()
-        except (hpilo.IloError, hpilo.IloFeatureNotSupported) as err:
-            _LOGGER.debug("Could not get server name: %s", err)
-        
-        # Get host data (SMBIOS entries for model, BIOS version, etc.)
-        try:
-            data.host_data = ilo.get_host_data()
-        except (hpilo.IloError, hpilo.IloFeatureNotSupported) as err:
-            _LOGGER.debug("Could not get host data: %s", err)
-        
+
+        def _try(label, fn):
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    return fn()
+            except (hpilo.IloError, hpilo.IloFeatureNotSupported) as err:
+                _LOGGER.debug("Could not get %s: %s", label, err)
+            return None
+
+        data.health           = _try("embedded health",       ilo.get_embedded_health)
+        data.power_status     = _try("power status",          ilo.get_host_power_status)
+        data.power_on_time    = _try("power on time",         ilo.get_server_power_on_time)
+        data.server_name      = _try("server name",           ilo.get_server_name)
+        data.network_settings = _try("network settings",      ilo.get_network_settings)
+        data.host_data        = _try("host data",             ilo.get_host_data)
+        data.fw_version       = _try("firmware version",      ilo.get_fw_version)
+        data.power_readings   = _try("power readings",        ilo.get_power_readings)
+        data.uid_status       = _try("UID status",            ilo.get_uid_status)
+        data.power_saver      = _try("power saver status",    ilo.get_host_power_saver_status)
+        data.pwreg            = _try("power regulation",      ilo.get_pwreg)
+        data.ilo_event_log    = _try("iLO event log",         ilo.get_ilo_event_log)
+        data.server_event_log = _try("server event log",      ilo.get_server_event_log)
+
+        raw = _try("critical temp remain off", ilo.get_critical_temp_remain_off)
+        if raw is not None:
+            data.critical_temp_remain_off = (
+                raw.get("critical_temp_remain_off", "No").upper() == "YES"
+            )
+
+        # asset tag returns {'asset_tag': 'NL00001'} or {'asset_tag': None}
+        raw_tag = _try("asset tag", ilo.get_asset_tag)
+        if raw_tag is not None:
+            data.asset_tag = raw_tag.get("asset_tag")
+
         _LOGGER.debug("Successfully fetched data from HP iLO")
         return data

--- a/custom_components/hp_ilo/sensor.py
+++ b/custom_components/hp_ilo/sensor.py
@@ -1,7 +1,8 @@
-"""Support for information from HP iLO sensors."""
+"""Support for HP iLO sensors."""
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import hpilo
@@ -31,13 +32,14 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VALUE_TEMPLATE,
     PERCENTAGE,
+    UnitOfPower,
     UnitOfTemperature,
     UnitOfTime,
 )
 from homeassistant.helpers.device_registry import CONNECTION_UPNP
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -96,11 +98,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up device and sensor entities for a config entry."""
-    
-    # Get the coordinator from hass.data
+
     coordinator: HpIloDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # config flow sets this to either UUID, serial number or None
     if (unique_id := entry.unique_id) is None:
         unique_id = entry.entry_id
 
@@ -114,177 +114,949 @@ async def async_setup_entry(
         manufacturer="Hewlett Packard Enterprise",
         configuration_url=configuration_url,
         connections=connections,
-        identifiers=identifiers
+        identifiers=identifiers,
     )
 
     sensors: list[SensorEntity] = []
-    
-    # Get initial data from coordinator
     data = coordinator.data
-    
-    # Process health data for temperature and fan sensors
+
+    # ------------------------------------------------------------------ health
     if data.health:
         health = data.health
-        
+
         # Temperature sensors
         if 'temperature' in health:
             for temp_sensor in health['temperature'].values():
                 if temp_sensor.get('status') != 'Not Installed':
                     label = temp_sensor['label']
                     _LOGGER.info("Adding sensor for Temperature Sensor %s", label)
-                    sensors.append(
-                        HpIloTemperatureSensor(
-                            coordinator=coordinator,
-                            entry=entry,
-                            device_info=device_info,
-                            sensor_label=label,
-                        )
-                    )
-        
+                    sensors.append(HpIloTemperatureSensor(coordinator, entry, device_info, label))
+
         # Fan sensors
         if 'fans' in health:
             for fan_sensor in health['fans'].values():
                 label = fan_sensor['label']
                 _LOGGER.info("Adding sensor for Fan %s", label)
-                sensors.append(
-                    HpIloFanSensor(
-                        coordinator=coordinator,
-                        entry=entry,
-                        device_info=device_info,
-                        sensor_label=label,
-                    )
-                )
-        
-        # Update device_info with firmware version
+                sensors.append(HpIloFanSensor(coordinator, entry, device_info, label))
+
+        # Memory sensors — data lives in memory_components as a list of lists of tuples
+        if 'memory' in health:
+            memory = health['memory']
+            components = memory.get('memory_components', []) if isinstance(memory, dict) else []
+            for component in components:
+                # Each component is a list of (field_name, {'value': ...}) tuples
+                fields = {k: v.get('value') for k, v in component if isinstance(v, dict)}
+                location = fields.get('memory_location', '').strip()
+                size = fields.get('memory_size', 'Not Installed')
+                if location and size and size != 'Not Installed':
+                    _LOGGER.info("Adding sensor for Memory %s", location)
+                    sensors.append(HpIloMemorySensor(coordinator, entry, device_info, location))
+
+        # Processor sensors
+        if 'processors' in health:
+            for proc_key, proc_data in health['processors'].items():
+                if isinstance(proc_data, dict) and proc_data.get('status', 'Unknown') not in ('Not Installed', 'Unknown'):
+                    _LOGGER.info("Adding sensor for Processor %s", proc_key)
+                    sensors.append(HpIloProcessorSensor(coordinator, entry, device_info, proc_key))
+                    # Per-field sensors for type, speed and execution technology
+                    for field, label in (
+                        ('name',                f'{proc_key} Name'),
+                        ('speed',               f'{proc_key} Speed'),
+                        ('execution_technology', f'{proc_key} Execution Technology'),
+                        ('memory_technology',    f'{proc_key} Memory Technology'),
+                    ):
+                        if field in proc_data:
+                            sensors.append(HpIloProcessorFieldSensor(
+                                coordinator, entry, device_info, proc_key, field, label
+                            ))
+
+        # NIC sensors
+        if 'nic_information' in health:
+            for nic_key, nic_data in health['nic_information'].items():
+                if isinstance(nic_data, dict):
+                    _LOGGER.info("Adding sensor for NIC %s", nic_key)
+                    sensors.append(HpIloNicSensor(coordinator, entry, device_info, nic_key))
+
+        # Storage controller sensors
+        if 'storage' in health:
+            storage_data = health['storage']
+            if not isinstance(storage_data, dict):
+                storage_data = {}
+            for ctrl_key, ctrl_data in storage_data.items():
+                if isinstance(ctrl_data, dict):
+                    _LOGGER.info("Adding sensor for Storage Controller %s", ctrl_key)
+                    sensors.append(HpIloStorageControllerSensor(coordinator, entry, device_info, ctrl_key))
+
+        # BIOS/Hardware aggregate sensor
+        if 'bios_hardware' in health:
+            _LOGGER.info("Adding sensor for BIOS Hardware Status")
+            sensors.append(HpIloBiosHardwareSensor(coordinator, entry, device_info))
+
+        # Enrich device_info from firmware_information block inside health
         if 'firmware_information' in health:
             fw_info = health['firmware_information']
             if 'iLO' in fw_info:
                 device_info['sw_version'] = fw_info['iLO']
-    
-    # Process host data for device info
+
+            # Explicit label overrides for known keys; all other keys get a
+            # cleaned-up label automatically so new firmware components are
+            # always picked up regardless of server generation.
+            FW_LABEL_OVERRIDES = {
+                'iLO':                                        None,  # shown in device_info, skip as sensor
+                'System ROM':                                 'System ROM',
+                'Redundant System ROM':                       'Redundant System ROM',
+                'System ROM Bootblock':                       'System ROM Bootblock',
+                'Intelligent Provisioning':                   'Intelligent Provisioning',
+                'Intelligent Platform Abstraction Data':      'Intelligent Platform Abstraction Data',
+                'Power Management Controller Firmware':       'Power Management Controller Firmware',
+                'Power Management Controller Firmware Bootloader': 'Power Management Controller Bootloader',
+                'Server Platform Services (SPS) Firmware':   'SPS Firmware',
+                'System Programmable Logic Device':           'System Programmable Logic Device',
+            }
+            for fw_key, fw_val in fw_info.items():
+                if fw_val is None:
+                    continue
+                # Skip iLO — already in device_info
+                if fw_key == 'iLO':
+                    continue
+                fw_label = FW_LABEL_OVERRIDES.get(fw_key, fw_key)
+                _LOGGER.info("Adding sensor for firmware component: %s", fw_label)
+                sensors.append(HpIloFirmwareComponentSensor(
+                    coordinator, entry, device_info, fw_key, fw_label
+                ))
+
+        # iLO health-at-a-glance self-test sensors (one per subsystem)
+        if 'health_at_a_glance' in health:
+            for subsystem_key, subsystem_data in health['health_at_a_glance'].items():
+                if isinstance(subsystem_data, dict):
+                    label = subsystem_key.replace('_', ' ').title()
+                    _LOGGER.info("Adding health-at-a-glance sensor for: %s", label)
+                    sensors.append(HpIloHealthAtAGlanceSensor(
+                        coordinator, entry, device_info, subsystem_key, label
+                    ))
+
+    # ---------------------------------------------------------------- host data
     if data.host_data:
         for smbios_value in data.host_data:
-            if smbios_value.get('type') == 0:  # BIOS Information
+            if smbios_value.get('type') == 0:
                 device_info['hw_version'] = f"{smbios_value.get('Family', '')} {smbios_value.get('Date', '')}"
-            if smbios_value.get('type') == 1:  # System Information
+            if smbios_value.get('type') == 1:
                 device_info['model'] = smbios_value.get('Product Name')
-    
-    # Power on time sensor
+
+    # --------------------------------------------------------------- fw version
+    if data.fw_version:
+        _LOGGER.info("Adding sensor for iLO Firmware")
+        sensors.append(HpIloFirmwareSensor(coordinator, entry, device_info))
+        # Also enrich device_info
+        if 'firmware_version' in data.fw_version:
+            device_info['sw_version'] = data.fw_version['firmware_version']
+
+    # ------------------------------------------------------------ power sensors
     if data.power_on_time is not None:
         _LOGGER.info("Adding sensor for Server Power On time")
-        sensors.append(
-            HpIloPowerOnTimeSensor(
-                coordinator=coordinator,
-                entry=entry,
-                device_info=device_info,
-            )
-        )
+        sensors.append(HpIloPowerOnTimeSensor(coordinator, entry, device_info))
+
+    if data.power_readings is not None:
+        _LOGGER.info("Adding power reading sensors")
+        for reading_key, label in (
+            ('present_power_reading', 'Present Power'),
+            ('average_power_reading', 'Average Power'),
+            ('minimum_power_reading', 'Minimum Power'),
+            ('maximum_power_reading', 'Maximum Power'),
+        ):
+            if reading_key in data.power_readings:
+                sensors.append(HpIloPowerReadingSensor(coordinator, entry, device_info, reading_key, label))
+
+    # -------------------------------------------------------------- power saver
+    if data.power_saver is not None:
+        _LOGGER.info("Adding sensor for Power Saver mode")
+        sensors.append(HpIloPowerSaverSensor(coordinator, entry, device_info))
+
+    # ------------------------------------------------------------------- pwreg
+    if data.pwreg is not None:
+        _LOGGER.info("Adding sensor for Power Regulation")
+        sensors.append(HpIloPowerRegSensor(coordinator, entry, device_info))
+
+    # ---------------------------------------------------------------- asset tag
+    # Always add if the API call succeeded (value may be None = not set)
+    if data.asset_tag is not None:
+        _LOGGER.info("Adding sensor for Asset Tag")
+        sensors.append(HpIloAssetTagSensor(coordinator, entry, device_info))
+
+    # ------------------------------------------------------------ event log sensors
+    if data.ilo_event_log is not None:
+        _LOGGER.info("Adding sensors for iLO Event Log")
+        sensors.append(HpIloEventLogSensor(coordinator, entry, device_info, "ilo"))
+        for field, label in (
+            ('description', 'iLO Event Log Last Description'),
+            ('last_update',  'iLO Event Log Last Timestamp'),
+            ('class',        'iLO Event Log Last Class'),
+        ):
+            sensors.append(HpIloEventLogFieldSensor(coordinator, entry, device_info, "ilo", field, label))
+
+    if data.server_event_log is not None:
+        _LOGGER.info("Adding sensors for Server Event Log")
+        sensors.append(HpIloEventLogSensor(coordinator, entry, device_info, "server"))
+        for field, label in (
+            ('description', 'Server Event Log Last Description'),
+            ('last_update',  'Server Event Log Last Timestamp'),
+            ('class',        'Server Event Log Last Class'),
+        ):
+            sensors.append(HpIloEventLogFieldSensor(coordinator, entry, device_info, "server", field, label))
 
     async_add_entities(sensors, False)
 
 
-class HpIloTemperatureSensor(CoordinatorEntity[HpIloDataUpdateCoordinator], SensorEntity):
-    """Representation of an HP iLO temperature sensor."""
+# ---------------------------------------------------------------------------
+# Base helper
+# ---------------------------------------------------------------------------
+
+class _HpIloSensor(CoordinatorEntity[HpIloDataUpdateCoordinator], SensorEntity):
+    """Shared base for all HP iLO sensor entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HpIloDataUpdateCoordinator,
+        entry: ConfigEntry,
+        device_info: DeviceInfo,
+        unique_suffix: str,
+        name: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = device_info
+        self._attr_name = name
+        self._attr_unique_id = f"{entry.data['unique_id']}_{unique_suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Health sensors (temperature, fan, memory, processor, NIC, storage, BIOS)
+# ---------------------------------------------------------------------------
+
+class HpIloTemperatureSensor(_HpIloSensor):
+    """HP iLO temperature sensor."""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
 
-    def __init__(
-        self,
-        coordinator: HpIloDataUpdateCoordinator,
-        entry: ConfigEntry,
-        device_info: DeviceInfo,
-        sensor_label: str,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
+    def __init__(self, coordinator, entry, device_info, sensor_label):
+        # Strip leading "NN-" prefix (e.g. "01-Inlet Ambient" → "Inlet Ambient")
+        # for the display name; keep the original as unique_id suffix to avoid
+        # collisions if two zones happen to share a name after stripping.
+        display_name = re.sub(r'^\d+-', '', sensor_label).strip()
+        super().__init__(coordinator, entry, device_info, sensor_label, display_name)
         self._sensor_label = sensor_label
-        self._attr_device_info = device_info
-        self._attr_name = sensor_label
-        self._attr_unique_id = f"{entry.data['unique_id']}_{sensor_label}"
 
     @property
     def native_value(self) -> float | None:
-        """Return the current temperature."""
         if not self.coordinator.data or not self.coordinator.data.health:
             return None
-        
-        temps = self.coordinator.data.health.get('temperature', {})
-        # Find sensor by label (dict is keyed by index, not label)
-        for sensor_data in temps.values():
+        for sensor_data in self.coordinator.data.health.get('temperature', {}).values():
             if sensor_data.get('label') == self._sensor_label:
-                if 'currentreading' in sensor_data:
-                    # currentreading is typically a tuple like (25, 'Celsius')
-                    reading = sensor_data['currentreading']
-                    if isinstance(reading, (list, tuple)) and len(reading) > 0:
-                        return reading[0]
-                    return reading
+                reading = sensor_data.get('currentreading')
+                if isinstance(reading, (list, tuple)):
+                    return reading[0]
+                return reading
         return None
 
 
-class HpIloFanSensor(CoordinatorEntity[HpIloDataUpdateCoordinator], SensorEntity):
-    """Representation of an HP iLO fan sensor."""
+class HpIloFanSensor(_HpIloSensor):
+    """HP iLO fan speed sensor."""
 
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:fan"
 
-    def __init__(
-        self,
-        coordinator: HpIloDataUpdateCoordinator,
-        entry: ConfigEntry,
-        device_info: DeviceInfo,
-        sensor_label: str,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
+    def __init__(self, coordinator, entry, device_info, sensor_label):
+        super().__init__(coordinator, entry, device_info, sensor_label, sensor_label)
         self._sensor_label = sensor_label
-        self._attr_device_info = device_info
-        self._attr_name = sensor_label
-        self._attr_unique_id = f"{entry.data['unique_id']}_{sensor_label}"
 
     @property
     def native_value(self) -> int | None:
-        """Return the current fan speed percentage."""
         if not self.coordinator.data or not self.coordinator.data.health:
             return None
-        
-        fans = self.coordinator.data.health.get('fans', {})
-        # Find sensor by label (dict is keyed by index, not label)
-        for sensor_data in fans.values():
+        for sensor_data in self.coordinator.data.health.get('fans', {}).values():
             if sensor_data.get('label') == self._sensor_label:
-                if 'speed' in sensor_data:
-                    # speed is typically a tuple like (28, 'Percentage')
-                    speed = sensor_data['speed']
-                    if isinstance(speed, (list, tuple)) and len(speed) > 0:
-                        return speed[0]
-                    return speed
+                speed = sensor_data.get('speed')
+                if isinstance(speed, (list, tuple)):
+                    return speed[0]
+                return speed
         return None
 
 
-class HpIloPowerOnTimeSensor(CoordinatorEntity[HpIloDataUpdateCoordinator], SensorEntity):
-    """Representation of an HP iLO power on time sensor."""
+class HpIloMemorySensor(_HpIloSensor):
+    """HP iLO memory DIMM sensor.
+
+    Data comes from health['memory']['memory_components'] which is a list of
+    lists of (field_name, {'value': ...}) tuples — one list per DIMM slot.
+
+    native_value → size (e.g. '8192 MB')
+    Attributes   → location, speed
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:memory"
+
+    def __init__(self, coordinator, entry, device_info, location: str):
+        # Use location string as both unique suffix and display name
+        unique_suffix = "memory_" + location.strip().lower().replace(' ', '_')
+        super().__init__(coordinator, entry, device_info, unique_suffix, location.strip())
+        self._location = location
+
+    def _get_fields(self) -> dict | None:
+        """Return the field dict for this DIMM slot, or None if not found."""
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        memory = self.coordinator.data.health.get('memory', {})
+        components = memory.get('memory_components', []) if isinstance(memory, dict) else []
+        for component in components:
+            fields = {k: v.get('value') for k, v in component if isinstance(v, dict)}
+            if fields.get('memory_location', '').strip() == self._location.strip():
+                return fields
+        return None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return size @ speed (e.g. '8192 MB @ 1600 MHz')."""
+        fields = self._get_fields()
+        if not fields:
+            return None
+        size = fields.get('memory_size', '')
+        speed = fields.get('memory_speed', '')
+        if size and speed and speed != '0 MHz':
+            return f"{size} @ {speed}"
+        return size or None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        fields = self._get_fields()
+        if not fields:
+            return {}
+        attrs: dict[str, Any] = {}
+        if 'memory_location' in fields:
+            attrs['location'] = fields['memory_location'].strip()
+        size = fields.get('memory_size', '')
+        speed = fields.get('memory_speed', '')
+        if size:
+            attrs['size'] = size
+        if speed and speed != '0 MHz':
+            attrs['speed'] = speed
+            # Infer DDR generation from speed
+            try:
+                mhz = int(speed.replace('MHz', '').strip())
+                if mhz <= 1066:
+                    attrs['type'] = 'DDR2'
+                elif mhz <= 1866:
+                    attrs['type'] = 'DDR3'
+                elif mhz <= 3200:
+                    attrs['type'] = 'DDR4'
+                else:
+                    attrs['type'] = 'DDR5'
+            except ValueError:
+                pass
+        return attrs
+
+
+class HpIloProcessorSensor(_HpIloSensor):
+    """HP iLO CPU/processor sensor.
+
+    native_value → health status (OK / Degraded / …)
+    Attributes   → name, speed, execution_technology, cache sizes
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:cpu-64-bit"
+
+    def __init__(self, coordinator, entry, device_info, proc_key):
+        super().__init__(coordinator, entry, device_info, f"processor_{proc_key}", proc_key)
+        self._proc_key = proc_key
+
+    def _get_proc(self) -> dict | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        return self.coordinator.data.health.get('processors', {}).get(self._proc_key)
+
+    @property
+    def name(self) -> str:
+        proc = self._get_proc()
+        return proc.get('label', self._proc_key) if proc else self._proc_key
+
+    @property
+    def native_value(self) -> str | None:
+        proc = self._get_proc()
+        return proc.get('status') if proc else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        proc = self._get_proc()
+        if not proc:
+            return {}
+        attrs: dict[str, Any] = {}
+        for key in ('name', 'speed', 'execution_technology', 'memory_technology',
+                    'internal_l1_cache', 'internal_l2_cache', 'internal_l3_cache'):
+            if key in proc:
+                val = proc[key]
+                attrs[key] = val.strip() if isinstance(val, str) else val
+        return attrs
+
+
+class HpIloProcessorFieldSensor(_HpIloSensor):
+    """Exposes a single processor field (name, speed, execution_technology, memory_technology)
+    as a dedicated HA entity so it appears in the diagnostics panel.
+
+    native_value → the field value, stripped of whitespace
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:cpu-64-bit"
+
+    def __init__(self, coordinator, entry, device_info, proc_key: str, field: str, label: str):
+        super().__init__(coordinator, entry, device_info, f"processor_{proc_key}_{field}", label)
+        self._proc_key = proc_key
+        self._field = field
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        proc = self.coordinator.data.health.get('processors', {}).get(self._proc_key)
+        if not proc:
+            return None
+        val = proc.get(self._field)
+        return str(val).strip()[:255] if val is not None else None
+
+
+class HpIloNicSensor(_HpIloSensor):
+    """HP iLO NIC sensor.
+
+    Merges nic_information (MAC, port, link status) with network_settings
+    (IP, subnet, gateway, DNS, DHCP, speed/duplex) matched by MAC address.
+
+    native_value → IP address when available, otherwise None
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:ethernet"
+
+    def __init__(self, coordinator, entry, device_info, nic_key):
+        super().__init__(coordinator, entry, device_info, f"nic_{nic_key}", nic_key)
+        self._nic_key = nic_key
+
+    def _get_nic(self) -> dict | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        return self.coordinator.data.health.get('nic_information', {}).get(self._nic_key)
+
+    def _get_ns(self) -> dict | None:
+        """Return network_settings for this NIC.
+
+        There is only one iLO management NIC. The MAC addresses reported by
+        nic_information and network_settings differ by design (shared NIC vs
+        iLO dedicated port share the same physical adapter but have different
+        MACs), so we always merge rather than cross-checking.
+        """
+        return self.coordinator.data.network_settings if self.coordinator.data else None
+
+    @property
+    def name(self) -> str:
+        nic = self._get_nic()
+        if not nic:
+            return self._nic_key
+        desc = nic.get('port_description', '').strip()
+        location = nic.get('location', '').strip()
+        port = nic.get('network_port', '').strip()
+        return f"{location} {desc} {port}".strip() or self._nic_key
+
+    @property
+    def native_value(self) -> str | None:
+        """Return IP address if known, MAC address as stable fallback."""
+        ns = self._get_ns()
+        if ns:
+            ip = ns.get('ip_address') or ns.get('ipv4_address')
+            if ip and ip not in ('N/A', '0.0.0.0', ''):
+                return ip
+        nic = self._get_nic()
+        if nic:
+            ip = nic.get('ip_address')
+            if ip and ip not in ('N/A', ''):
+                return ip
+            # Fall back to MAC address — always present and meaningful
+            mac = nic.get('mac_address')
+            if mac:
+                return mac
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+        nic = self._get_nic()
+        if nic:
+            for key in ('mac_address', 'location', 'network_port', 'port_description', 'status'):
+                if key in nic:
+                    attrs[key] = nic[key]
+        ns = self._get_ns()
+        if ns:
+            for key in ('ip_address', 'subnet_mask', 'gateway_ip_address',
+                        'dns_name', 'domain_name', 'dhcp_enabled',
+                        'speed_autoselect', 'nic_speed', 'full_duplex',
+                        'ipv6_address', 'ipv6_static_route'):
+                val = ns.get(key)
+                if val is not None and val not in ('N/A', ''):
+                    attrs[key] = val
+        return attrs
+
+
+class HpIloStorageControllerSensor(_HpIloSensor):
+    """HP iLO storage controller sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:harddisk"
+
+    def __init__(self, coordinator, entry, device_info, ctrl_key):
+        super().__init__(coordinator, entry, device_info, f"storage_{ctrl_key}", ctrl_key)
+        self._ctrl_key = ctrl_key
+
+    def _get_ctrl(self) -> dict | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        return self.coordinator.data.health.get('storage', {}).get(self._ctrl_key)
+
+    @property
+    def name(self) -> str:
+        ctrl = self._get_ctrl()
+        return ctrl.get('label', self._ctrl_key) if ctrl else self._ctrl_key
+
+    @property
+    def native_value(self) -> str | None:
+        ctrl = self._get_ctrl()
+        return ctrl.get('status') if ctrl else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        ctrl = self._get_ctrl()
+        if not ctrl:
+            return {}
+        return {k: ([str(i) for i in v] if isinstance(v, list) else v)
+                for k, v in ctrl.items() if k not in ('label', 'status')}
+
+
+class HpIloBiosHardwareSensor(_HpIloSensor):
+    """HP iLO BIOS/Hardware aggregate health sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:chip"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "bios_hardware", "BIOS Hardware")
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        bios_hw = self.coordinator.data.health.get('bios_hardware')
+        if bios_hw is None:
+            return None
+        return bios_hw.get('status') if isinstance(bios_hw, dict) else str(bios_hw)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return {}
+        bios_hw = self.coordinator.data.health.get('bios_hardware', {})
+        return {k: v for k, v in bios_hw.items() if k != 'status'} if isinstance(bios_hw, dict) else {}
+
+
+# ---------------------------------------------------------------------------
+# Power sensors
+# ---------------------------------------------------------------------------
+
+class HpIloPowerOnTimeSensor(_HpIloSensor):
+    """HP iLO server power-on duration sensor."""
 
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
     _attr_suggested_unit_of_measurement = UnitOfTime.DAYS
 
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "Server Power On time", "Server Power On time")
+
+    @property
+    def native_value(self) -> int | None:
+        return self.coordinator.data.power_on_time if self.coordinator.data else None
+
+
+class HpIloPowerReadingSensor(_HpIloSensor):
+    """HP iLO power reading sensor (present / average / min / max watts)."""
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, entry, device_info, reading_key: str, label: str):
+        super().__init__(coordinator, entry, device_info, f"power_{reading_key}", label)
+        self._reading_key = reading_key
+
+    @property
+    def native_value(self) -> float | None:
+        if not self.coordinator.data or not self.coordinator.data.power_readings:
+            return None
+        reading = self.coordinator.data.power_readings.get(self._reading_key)
+        if isinstance(reading, (list, tuple)):
+            return reading[0]
+        return reading
+
+
+class HpIloPowerSaverSensor(_HpIloSensor):
+    """HP iLO power regulator/saver mode sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:lightning-bolt"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "power_saver", "Power Saver Mode")
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data or not self.coordinator.data.power_saver:
+            return None
+        return self.coordinator.data.power_saver.get('host_power_saver')
+
+
+class HpIloPowerRegSensor(_HpIloSensor):
+    """HP iLO power cap / efficiency / alert regulation sensor.
+
+    native_value → power cap mode (OFF / DYNAMIC / STATIC)
+    Attributes   → efficiency_mode, alert threshold/duration
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:speedometer"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "power_reg", "Power Cap Mode")
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data or not self.coordinator.data.pwreg:
+            return None
+        pcap = self.coordinator.data.pwreg.get('pcap', {})
+        return pcap.get('mode') if isinstance(pcap, dict) else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.data or not self.coordinator.data.pwreg:
+            return {}
+        pwreg = self.coordinator.data.pwreg
+        attrs: dict[str, Any] = {}
+        if 'efficiency_mode' in pwreg:
+            attrs['efficiency_mode'] = pwreg['efficiency_mode']
+        alert = pwreg.get('pwralert', {})
+        if isinstance(alert, dict):
+            for key in ('type', 'threshold', 'duration'):
+                if key in alert:
+                    attrs[f'alert_{key}'] = alert[key]
+        return attrs
+
+
+# ---------------------------------------------------------------------------
+# iLO identity / configuration sensors
+# ---------------------------------------------------------------------------
+
+class HpIloFirmwareSensor(_HpIloSensor):
+    """HP iLO firmware version / type / license sensor.
+
+    native_value → firmware version string (e.g. "2.10")
+    Attributes   → management_processor, license_type, firmware_date
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:chip"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "ilo_firmware", "iLO Firmware Version")
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data or not self.coordinator.data.fw_version:
+            return None
+        return self.coordinator.data.fw_version.get('firmware_version')
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        if not self.coordinator.data or not self.coordinator.data.fw_version:
+            return {}
+        return {k: v for k, v in self.coordinator.data.fw_version.items()
+                if k != 'firmware_version'}
+
+
+class HpIloAssetTagSensor(_HpIloSensor):
+    """HP iLO server asset tag sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:tag"
+
+    def __init__(self, coordinator, entry, device_info):
+        super().__init__(coordinator, entry, device_info, "asset_tag", "Asset Tag")
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.asset_tag
+
+
+# ---------------------------------------------------------------------------
+# Event log sensors
+# ---------------------------------------------------------------------------
+
+class HpIloEventLogSensor(_HpIloSensor):
+    """HP iLO event log sensor.
+
+    native_value → worst severity present in the log
+                   (Critical > Caution > Informational)
+    Attributes   → most_recent (description, class, timestamp of newest entry)
+                   entries     (up to 50 most-recent entries, newest first)
+                   total_entries
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    # Severity ranking — higher index = worse
+    _SEVERITY_RANK = ["informational", "repaired", "caution", "critical"]
+
+    _SEVERITY_ICON = {
+        "informational": "mdi:information-outline",
+        "caution":       "mdi:alert-outline",
+        "critical":      "mdi:alert-circle-outline",
+    }
+
+    # Maximum number of entries to include in the attribute (HA attr size limit)
+    _MAX_ENTRIES = 50
+
+    def __init__(self, coordinator, entry, device_info, log_type: str):
+        label = "iLO Event Log" if log_type == "ilo" else "Server Event Log"
+        super().__init__(coordinator, entry, device_info, f"{log_type}_event_log", label)
+        self._log_type = log_type
+
+    def _get_log(self) -> list[dict] | None:
+        if not self.coordinator.data:
+            return None
+        return (self.coordinator.data.ilo_event_log
+                if self._log_type == "ilo"
+                else self.coordinator.data.server_event_log)
+
+    @property
+    def icon(self) -> str:
+        severity = (self.native_value or "").lower()
+        return self._SEVERITY_ICON.get(severity, "mdi:text-box-outline")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the worst severity found across all log entries."""
+        log = self._get_log()
+        if not log:
+            return None
+        worst_rank = -1
+        worst_severity = None
+        for entry in log:
+            severity = (entry.get('severity') or '').lower()
+            rank = self._SEVERITY_RANK.index(severity) if severity in self._SEVERITY_RANK else 0
+            if rank > worst_rank:
+                worst_rank = rank
+                worst_severity = entry.get('severity')
+        return worst_severity
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        log = self._get_log()
+        if not log:
+            return {}
+
+        # Most recent entry (last in list)
+        newest = log[-1]
+        most_recent = {
+            'severity':       newest.get('severity'),
+            'description':    newest.get('description'),
+            'class':          newest.get('class'),
+            'last_update':    newest.get('last_update'),
+            'initial_update': newest.get('initial_update'),
+            'count':          newest.get('count'),
+        }
+
+        # Full log, newest first, capped at _MAX_ENTRIES
+        entries = []
+        for e in reversed(log[-self._MAX_ENTRIES:]):
+            entries.append({
+                k: v for k, v in e.items()
+                if v is not None and v != ''
+            })
+
+        return {
+            'most_recent':   most_recent,
+            'entries':       entries,
+            'total_entries': len(log),
+        }
+
+class HpIloEventLogFieldSensor(_HpIloSensor):
+    """Exposes a single field of the most-recent critical (or worst) event log entry as a HA entity.
+
+    This makes individual fields (description, timestamp, class) visible as
+    first-class entities in the HA UI rather than buried inside attributes.
+
+    native_value → the field value from the worst-severity entry in the log,
+                   truncated to 255 chars (HA state limit)
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:text-box-outline"
+
+    _SEVERITY_RANK = ["informational", "repaired", "caution", "critical"]
+
     def __init__(
         self,
         coordinator: HpIloDataUpdateCoordinator,
         entry: ConfigEntry,
         device_info: DeviceInfo,
+        log_type: str,
+        field: str,
+        label: str,
     ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._attr_device_info = device_info
-        self._attr_name = "Server Power On time"
-        self._attr_unique_id = f"{entry.data['unique_id']}_Server Power On time"
+        super().__init__(coordinator, entry, device_info, f"{log_type}_event_log_{field}", label)
+        self._log_type = log_type
+        self._field = field
 
-    @property
-    def native_value(self) -> int | None:
-        """Return the power on time in minutes."""
+    def _get_worst_entry(self) -> dict | None:
         if not self.coordinator.data:
             return None
-        return self.coordinator.data.power_on_time
+        log = (self.coordinator.data.ilo_event_log
+               if self._log_type == "ilo"
+               else self.coordinator.data.server_event_log)
+        if not log:
+            return None
+        worst_rank = -1
+        worst_entry = None
+        for e in log:
+            severity = (e.get('severity') or '').lower()
+            rank = self._SEVERITY_RANK.index(severity) if severity in self._SEVERITY_RANK else 0
+            if rank > worst_rank:
+                worst_rank = rank
+                worst_entry = e
+        return worst_entry
+
+    @property
+    def native_value(self) -> str | None:
+        entry = self._get_worst_entry()
+        if not entry:
+            return None
+        val = entry.get(self._field)
+        if val is None:
+            return None
+        # HA state is capped at 255 characters
+        return str(val)[:255]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the full worst entry for context."""
+        entry = self._get_worst_entry()
+        if not entry:
+            return {}
+        return {k: v for k, v in entry.items() if v is not None and v != ''}
+
+
+# ---------------------------------------------------------------------------
+# Firmware component sensors (from health['firmware_information'])
+# ---------------------------------------------------------------------------
+
+class HpIloFirmwareComponentSensor(_HpIloSensor):
+    """Sensor for a single firmware component from health['firmware_information'].
+
+    Covers System ROM, Backup ROM, Bootblock, Power Management Controller,
+    SPS Firmware, System Programmable Logic Device, etc.
+
+    native_value → version/date string for that component
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:chip"
+
+    def __init__(
+        self,
+        coordinator: HpIloDataUpdateCoordinator,
+        entry: ConfigEntry,
+        device_info: DeviceInfo,
+        fw_key: str,
+        label: str,
+    ) -> None:
+        # Use a safe unique suffix derived from the key
+        unique_suffix = "fw_" + fw_key.lower().replace(' ', '_').replace('-', '_').replace('(', '').replace(')', '')
+        super().__init__(coordinator, entry, device_info, unique_suffix, label)
+        self._fw_key = fw_key
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        fw_info = self.coordinator.data.health.get('firmware_information', {})
+        val = fw_info.get(self._fw_key)
+        return str(val)[:255] if val is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Health-at-a-glance self-test sensors (from health['health_at_a_glance'])
+# ---------------------------------------------------------------------------
+
+class HpIloHealthAtAGlanceSensor(_HpIloSensor):
+    """Sensor for a single subsystem from health['health_at_a_glance'].
+
+    This is the iLO's own rolled-up self-test result per subsystem
+    (bios_hardware, fans, memory, network, processor, storage, temperature).
+
+    native_value → status string (OK / Degraded / Failed / Not Installed / …)
+    Attributes   → any additional fields iLO returns for that subsystem
+                   (e.g. redundancy status)
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    _STATUS_ICON = {
+        'ok':           'mdi:check-circle-outline',
+        'degraded':     'mdi:alert-outline',
+        'failed':       'mdi:close-circle-outline',
+        'critical':     'mdi:alert-circle-outline',
+        'not installed': 'mdi:minus-circle-outline',
+    }
+
+    def __init__(
+        self,
+        coordinator: HpIloDataUpdateCoordinator,
+        entry: ConfigEntry,
+        device_info: DeviceInfo,
+        subsystem_key: str,
+        label: str,
+    ) -> None:
+        super().__init__(coordinator, entry, device_info, f"haag_{subsystem_key}", label)
+        self._subsystem_key = subsystem_key
+
+    def _get_data(self) -> dict | None:
+        if not self.coordinator.data or not self.coordinator.data.health:
+            return None
+        return self.coordinator.data.health.get('health_at_a_glance', {}).get(self._subsystem_key)
+
+    @property
+    def icon(self) -> str:
+        status = (self.native_value or '').lower()
+        return self._STATUS_ICON.get(status, 'mdi:help-circle-outline')
+
+    @property
+    def native_value(self) -> str | None:
+        data = self._get_data()
+        return data.get('status') if data else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        data = self._get_data()
+        if not data:
+            return {}
+        return {k: v for k, v in data.items() if k != 'status'}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Implement more diagnostic &amp; sensor entities</h1>
<h2>Summary</h2>
<p>This PR significantly expands the HP iLO integration with comprehensive hardware monitoring, firmware tracking, event log access, and health diagnostics — surfacing data that was previously only visible in the iLO web UI directly into Home Assistant as first-class entities.</p>
<hr>
<h2>New Entities</h2>
<h3>Sensors (diagnostic category)</h3>

Entity | Source | Notes
-- | -- | --
System ROM | firmware_information | e.g. J04 04/04/2019
Redundant System ROM | firmware_information | Backup ROM version/date
System ROM Bootblock | firmware_information |  
Intelligent Provisioning | firmware_information |  
Intelligent Platform Abstraction Data | firmware_information |  
SPS Firmware | firmware_information |  
System Programmable Logic Device | firmware_information |  
Memory DIMM sensors | memory_components | Per installed DIMM: size @ speed, type inferred from speed (DDR3/DDR4/DDR5), location attribute
Processor status | processors | Per CPU: status as state
Proc N Name | processors | e.g. Intel(R) Xeon(R) CPU E3-1220 V2 @ 3.10GHz
Proc N Speed | processors | e.g. 3100 MHz
Proc N Execution Technology | processors | e.g. 4/4 cores; 4 threads
Proc N Memory Technology | processors | e.g. 64-bit Capable
NIC sensor | nic_information + network_settings | MAC, IP, gateway, DNS, speed/duplex as attributes
Storage controller sensors | storage | Per controller: drive list and logical volumes as attributes
BIOS Hardware | bios_hardware | Aggregate health status
iLO Firmware Version | get_fw_version | Management processor type, license, date as attributes
Asset Tag | get_asset_tag |  
Power Saver Mode | get_host_power_saver_status | AUTO / OS Control / Static High / Static Low
Power Cap Mode | get_pwreg | OFF / DYNAMIC / STATIC; efficiency mode and alert thresholds as attributes
Present / Average / Minimum / Maximum Power | get_power_readings | Watts, SensorDeviceClass.POWER
iLO Event Log | get_ilo_event_log | Worst severity as state; full log (up to 50 entries, newest first) in attributes
Server Event Log | get_server_event_log | As above
iLO / Server Event Log Last Description | event log | Most recent critical entry description
iLO / Server Event Log Last Timestamp | event log | Timestamp of worst entry
iLO / Server Event Log Last Class | event log | Event class of worst entry
Health-at-a-glance sensors | health_at_a_glance | One sensor per iLO subsystem (BIOS, fans, temperature, power supplies, processor, memory, network, storage) — iLO's own self-test rollup


<hr>
<h2>Bug Fixes</h2>
<ul>
<li><strong><code>IloWarning</code> spam in logs</strong>: <code>warnings.catch_warnings()</code> context manager now wraps every API call, suppressing <code>IloWarning</code> (e.g. "No Asset Tag Information") from polluting the HA log.</li>
<li><strong>Storage sensor crash</strong>: <code>health['storage']</code> can be <code>None</code> rather than a missing key; guarded with <code>isinstance(..., dict)</code> check.</li>
<li><strong>NIC sensor showing <code>unknown</code></strong>: Falls back to MAC address as <code>native_value</code> when iLO reports <code>ip_address: 'N/A'</code> (as is the case for embedded shared NICs on Gen8).</li>
<li><strong>NIC MAC mismatch skipping merge</strong>: The iLO management port and shared NIC port on the same adapter use adjacent MACs (e.g. <code>...7d</code> vs <code>...7f</code>). Removed cross-check; <code>network_settings</code> is now always merged since there is only one iLO management NIC.</li>
<li><strong>Storage Health binary sensor <code>unknown</code></strong>: <code>is_on</code> returned <code>None</code> when subsystem data was <code>None</code>; now returns <code>False</code> (no problem detected).</li>
<li><strong>Memory sensor crash</strong>: <code>health['memory']</code> on Gen8 servers uses <code>memory_components</code> (list of lists of tuples) rather than <code>memory_details_summary</code> (dict). Sensor rewritten to parse the actual structure.</li>
<li><strong>Memory <code>Other</code> status false alarm</strong>: <code>health_at_a_glance['memory']['status']</code> returns <code>Other</code> for mixed-size/speed DIMM configurations. <code>Other</code> is now excluded from <code>_FAULT_STATUSES</code> in the health binary sensor.</li>
<li><strong>Firmware component sensors missing</strong>: <code>FW_COMPONENTS</code> used Gen8+ key names (<code>HP ProLiant System ROM</code>) but actual keys vary by generation (e.g. <code>System ROM</code>, <code>Redundant System ROM</code>). Replaced with dynamic iteration over all <code>firmware_information</code> keys with a label override table.</li>
<li><strong>Temperature sensor names with number prefix</strong>: Labels like <code>01-Inlet Ambient</code> stripped to <code>Inlet Ambient</code> for display; original label retained as unique ID to prevent duplicate collisions.</li>
<li><strong>Entity naming</strong>: Added <code>_attr_has_entity_name = True</code> to both <code>_HpIloSensor</code> and <code>_HpIloBinarySensor</code> base classes so HA automatically prefixes all entity names with the device name.</li>
<li><strong>All health/config entities marked <code>EntityCategory.DIAGNOSTIC</code></strong>: Separates monitoring entities from primary sensors in the HA device panel.</li>
</ul>
<hr>
<h2>Architecture</h2>
<ul>
<li><strong>Single polling cycle</strong>: All data is fetched once per 60-second coordinator refresh via a shared <code>_try()</code> helper that silently handles <code>IloError</code> / <code>IloFeatureNotSupported</code> per API call, so unsupported features (e.g. <code>get_power_readings</code> on older iLO) don't break the integration.</li>
<li><strong>13 API calls</strong> per refresh: <code>get_embedded_health</code>, <code>get_host_power_status</code>, <code>get_server_power_on_time</code>, <code>get_server_name</code>, <code>get_network_settings</code>, <code>get_host_data</code>, <code>get_fw_version</code>, <code>get_power_readings</code>, <code>get_uid_status</code>, <code>get_host_power_saver_status</code>, <code>get_pwreg</code>, <code>get_ilo_event_log</code>, <code>get_server_event_log</code>.</li>
</ul>
<hr>
<h2>Required Actions / Known Limitations</h2>
<h3>iLO user privileges</h3>
<p>The "Clear iLO Event Log" and "Clear Server Event Log" buttons require the <strong>Configure iLO Settings (<code>CONFIG_ILO_PRIV</code>)</strong> privilege on the iLO user account used by HA. Without it, pressing either button will log:</p>
<pre><code>Failed to clear iLO event log: User does NOT have correct privilege for action. CONFIG_ILO_PRIV required.
</code></pre>
<p>To grant the privilege: iLO web UI → <strong>Administration → User Administration</strong> → select the HA user → enable <strong>"Configure iLO Settings"</strong> → Save.</p>
<h3>iLO 4 / Gen8 specifics</h3>
<ul>
<li>Power readings (<code>get_power_readings</code>) and power regulation (<code>get_pwreg</code>) are not supported on all iLO 4 configurations and will log a debug-level message when unsupported.</li>
<li>Memory type (DDR3/DDR4/DDR5) is inferred from DIMM speed since RIBCL does not expose this field directly.</li>
<li><code>health_at_a_glance['memory']['status']</code> returns <code>Other</code> for mixed-capacity DIMM configurations — this is an iLO quirk, not a fault.</li>
</ul>
<hr>
<h2>Testing</h2>
<p>Tested against HP ProLiant MicroServer Gen8 with iLO 4 firmware <code>2.82 Feb 06 2023</code>, running an Intel Xeon E3-1220 V2 with mixed DDR3 DIMMs (8192 MB @ 1600 MHz + 4096 MB @ 1333 MHz).</p></body></html><!--EndFragment-->
</body>
</html>